### PR TITLE
Fixing moving nodes up/down & stopping modifying the dom during update

### DIFF
--- a/src/blot/abstract/container.ts
+++ b/src/blot/abstract/container.ts
@@ -154,28 +154,17 @@ abstract class ContainerBlot extends ShadowBlot implements Parent {
     });
     if (updated) {
       let childNode = this.domNode.firstChild;
-      this.children.forEach((child) => {
-        while (childNode !== child.domNode) {
-          if (child.domNode.parentNode === this.domNode) {
-            // New child inserted
-            let blot = Registry.find(childNode) || Registry.create(childNode);
-            if (blot.parent != null) {
-              blot.parent.children.remove(blot);
-            }
-            this.insertBefore(blot, child);
-            childNode = childNode.nextSibling;
-          } else {
-            // Existing child removed
-            return child.remove();
-          }
-        }
-        childNode = childNode.nextSibling;
-      });
-      while (childNode != null) {
+      let newChildren = new LinkedList<Blot>();
+      while (childNode) {
         let blot = Registry.find(childNode) || Registry.create(childNode);
-        this.insertBefore(blot);
+        if (blot.parent != null) {
+          blot.parent.children.remove(blot);
+        }
+        blot.parent = this;
+        newChildren.append(blot);
         childNode = childNode.nextSibling;
       }
+      this.children = newChildren;
     }
   }
 }

--- a/test/unit/lifecycle.js
+++ b/test/unit/lifecycle.js
@@ -256,6 +256,22 @@ describe('Lifecycle', function() {
         expect(this.container.descendants(ShadowBlot).length).toEqual(this.descendants.length);
       });
 
+      it('move node up', function() {
+        let imageBlot = this.descendants[4];
+        imageBlot.domNode.parentNode.insertBefore(imageBlot.domNode, imageBlot.domNode.previousSibling);
+        this.container.update();
+        this.checkUpdateCalls(imageBlot.parent);
+        this.checkValues([true, 'Test', 'ing', '!']);
+      });
+
+      it('move node down', function() {
+        let imageBlot = this.descendants[4];
+        imageBlot.domNode.parentNode.insertBefore(imageBlot.domNode.nextSibling, imageBlot.domNode);
+        this.container.update();
+        this.checkUpdateCalls(imageBlot.parent);
+        this.checkValues(['Test', 'ing', true, '!']);
+      });
+
       it('add and remove consecutive nodes', function() {
         let italicBlot = this.descendants[1];
         let imageNode = document.createElement('img');
@@ -266,7 +282,7 @@ describe('Lifecycle', function() {
         italicBlot.domNode.removeChild(refNode);
         this.container.update();
         this.checkUpdateCalls(italicBlot);
-        this.checkValues(['Test', '|', true, 'ing', '!'])
+        this.checkValues(['Test', true, '|', 'ing', '!'])
       });
 
       it('add then remove same node', function() {


### PR DESCRIPTION
There are 2 bugs fixed here
* moving dom elements up and down in the dom caused NPE errors as we ran out of nextSiblings
* this.insertBefore() and child.remove() mutated the dom which should never happen in an update call, the dom is already mutated and mutating it again was causing undesirable side effects