### PR TITLE
Fixes NPE that happens when a dom is unknown and detacted from the dom

### DIFF
--- a/src/blot/scroll.ts
+++ b/src/blot/scroll.ts
@@ -103,6 +103,7 @@ class ScrollBlot extends ContainerBlot {
     // TODO use WeakMap
     mutations.map(function(mutation: MutationRecord) {
       let blot = Registry.find(mutation.target, true);
+      if (blot == null) return;
       if (blot.domNode[Registry.DATA_KEY].mutations == null) {
         blot.domNode[Registry.DATA_KEY].mutations = [mutation];
         return blot;

--- a/test/unit/lifecycle.js
+++ b/test/unit/lifecycle.js
@@ -205,6 +205,16 @@ describe('Lifecycle', function() {
         expect(textBlot.value()).toEqual('Te|st');
       });
 
+      it('add/remove unknown element', function() {
+        let unknownElement = document.createElement('unknownElement');
+        let unknownElement2 = document.createElement('unknownElement2');
+        this.container.domNode.appendChild(unknownElement);
+        unknownElement.appendChild(unknownElement2);
+        this.container.domNode.removeChild(unknownElement);
+        this.container.update();
+        this.checkValues(['Test', true, 'ing', '!']);
+      });
+
       it('add attribute', function() {
         let attrBlot = this.descendants[1];
         attrBlot.domNode.setAttribute('id', 'blot');


### PR DESCRIPTION
With embeds, there's a chance that quill doesn't know about all dom elements within the embed because it doesn't need to. But if an add and remove mutation happens within that embed within the same lifecycle, it's possible that the Registry.find() won't return any known quill elements and NPE. This guards against that.