### PR TITLE
Added blot.destroy() method

### DIFF
--- a/src/blot/abstract/blot.ts
+++ b/src/blot/abstract/blot.ts
@@ -9,6 +9,7 @@ interface Blot extends LinkedNode {
   domNode: Node;
 
   clone(): Blot;
+  destroy(): void;
   insertInto(parentBlot: Parent, refBlot?: Blot): void;
   isolate(index: number, length: number): Blot;
   offset(root?: Blot): number;

--- a/src/blot/abstract/container.ts
+++ b/src/blot/abstract/container.ts
@@ -148,6 +148,13 @@ abstract class ContainerBlot extends ShadowBlot implements Parent {
     this.remove();
   }
 
+  destroy(): void {
+    super.destroy();
+    this.children.forEach(function(child) {
+        child.destroy();
+    });
+  }
+
   update(mutations: MutationRecord[]): void {
     let addedNodes = [], removedNodes = [];
     mutations.forEach((mutation) => {
@@ -160,6 +167,7 @@ abstract class ContainerBlot extends ShadowBlot implements Parent {
       let blot = Registry.find(node);
       if (blot == null || blot.domNode.parentNode === this.domNode || blot.parent == null) return;
       blot.parent.children.remove(blot);
+      blot.destroy();
     });
     addedNodes.sort(function(a, b) {
       if (a === b) return 0;

--- a/src/blot/abstract/shadow.ts
+++ b/src/blot/abstract/shadow.ts
@@ -54,6 +54,10 @@ abstract class ShadowBlot implements Blot {
     this.domNode[Registry.DATA_KEY] = { blot: this };
   }
 
+  destroy() {
+    delete this.domNode[Registry.DATA_KEY];
+  }
+
   clone(): Blot {
     let domNode = this.domNode.cloneNode();
     return <Blot>Registry.create(domNode);
@@ -113,13 +117,13 @@ abstract class ShadowBlot implements Blot {
     if (this.domNode.parentNode != null) {
       this.domNode.parentNode.removeChild(this.domNode);
     }
+    this.destroy();
     if (this.parent == null) return;
     this.parent.children.remove(this);
   }
 
   replace(target: Blot): void {
     if (target.parent == null) return;
-    this.remove();
     target.parent.insertBefore(this, target.next);
     target.remove();
   }

--- a/src/blot/scroll.ts
+++ b/src/blot/scroll.ts
@@ -31,6 +31,11 @@ class ScrollBlot extends ContainerBlot {
     this.observer.observe(this.domNode, OBSERVER_CONFIG);
   }
 
+  destroy() {
+    super.destroy();
+    this.observer.disconnect();
+  }
+
   deleteAt(index: number, length: number): void {
     this.update();
     if (index === 0 && length === this.length()) {
@@ -69,7 +74,7 @@ class ScrollBlot extends ContainerBlot {
     let optimize = function(blot: Blot) {  // Post-order traversal
       if (blot instanceof ContainerBlot) {
         blot.children.forEach(function(child) {
-          if (blot.domNode[Registry.DATA_KEY].mutations == null) return;
+          if (!child.domNode[Registry.DATA_KEY] || child.domNode[Registry.DATA_KEY].mutations == null) return;
           optimize(child);
         });
       }

--- a/test/unit/blot.js
+++ b/test/unit/blot.js
@@ -10,6 +10,13 @@ describe('Blot', function() {
     expect(boldBlot.offset(blockBlot)).toEqual(4);
   });
 
+  it('destroy()', function() {
+    let blot = Registry.create('block');
+    expect(blot.domNode[Registry.DATA_KEY]).toEqual({blot: blot});
+    blot.destroy();
+    expect(blot.domNode[Registry.DATA_KEY]).toEqual(undefined);
+  });
+
   it('wrap()', function() {
     let parent = Registry.create('block');
     let head = Registry.create('bold');

--- a/test/unit/container.js
+++ b/test/unit/container.js
@@ -28,4 +28,28 @@ describe('Container', function() {
       expect(this.blot.descendants(TextBlot, 1, 3).length).toEqual(2);
     });
   });
+
+  describe('destroy()', function() {
+    it('destroy', function() {
+      let node = document.createElement('p');
+      let blot = Registry.create(node);
+      expect(blot.domNode[Registry.DATA_KEY]).toEqual({blot: blot});
+      expect(blot.descendants(ShadowBlot).length).toEqual(0);
+      blot.destroy();
+      expect(blot.domNode[Registry.DATA_KEY]).toEqual(undefined);
+    });
+
+    it('destroy + children', function() {
+      let node = document.createElement('p');
+      node.innerHTML = '<span>0</span><em>1<strong>2</strong><img></em>4';
+      let blot = Registry.create(node);
+      expect(blot.domNode[Registry.DATA_KEY]).toEqual({blot: blot});
+      expect(blot.descendants(ShadowBlot).length).toEqual(8);
+      blot.destroy();
+      expect(blot.domNode[Registry.DATA_KEY]).toEqual(undefined);
+      blot.descendants(ShadowBlot).forEach(function(blot) {
+        expect(blot.domNode[Registry.DATA_KEY]).toEqual(undefined);
+      });
+    });
+  })
 });


### PR DESCRIPTION
This adds a destroy hook for blots, by default merely removes the Registry.DATA_KEY reference on the dom, but can also be used for any cleanup needed of blot code. This also adds a observer.disconnect to the scroll to avoid memory leaks.