### PR TITLE
descendants can now query by scope

### DIFF
--- a/src/blot/abstract/container.ts
+++ b/src/blot/abstract/container.ts
@@ -49,10 +49,13 @@ abstract class ContainerBlot extends ShadowBlot implements Parent {
     }
   }
 
-  descendants<T>(type: { new (): T; }, index: number = 0, length: number = Number.MAX_VALUE): T[] {
+  descendants<T>(type: { new (): T; } | Registry.Scope, index: number = 0, length: number = Number.MAX_VALUE): T[] {
     let descendants = [], lengthLeft = length;
     this.children.forEachAt(index, length, function(child, index, length) {
-      if (child instanceof type) {
+      if (typeof type === 'function' && child instanceof type) {
+        descendants.push(child);
+      }
+      if (typeof type === 'number' && Registry.query(child.domNode, type) != null) {
         descendants.push(child);
       }
       if (child instanceof ContainerBlot) {

--- a/test/unit/container.js
+++ b/test/unit/container.js
@@ -27,6 +27,10 @@ describe('Container', function() {
     it('range', function() {
       expect(this.blot.descendants(TextBlot, 1, 3).length).toEqual(2);
     });
+
+    it('scope.inline', function() {
+      expect(this.blot.descendants(Registry.Scope.INLINE).length).toEqual(8);
+    });
   });
 
   describe('detach()', function() {


### PR DESCRIPTION
Useful if you want to find all block elements instead of just block blots