### PR TITLE
fix cloneNode for old browsers

### DIFF
--- a/src/blot/abstract/shadow.ts
+++ b/src/blot/abstract/shadow.ts
@@ -55,7 +55,7 @@ class ShadowBlot implements Blot {
   }
 
   clone(): Blot {
-    let domNode = this.domNode.cloneNode();
+    let domNode = this.domNode.cloneNode(false);
     return Registry.create(domNode);
   }
 


### PR DESCRIPTION
For more details check note in yellow [here](https://developer.mozilla.org/en/docs/Web/API/Node/cloneNode)