### PR TITLE
Unquote value in `Attributor.canAdd` (fixes quilljs/quill#1769)

### DIFF
--- a/src/attributor/attributor.ts
+++ b/src/attributor/attributor.ts
@@ -38,7 +38,7 @@ export default class Attributor {
 
   canAdd(node: HTMLElement, value: string): boolean {
     let match = Registry.query(node, Registry.Scope.BLOT & (this.scope | Registry.Scope.TYPE));
-    if (match != null && (this.whitelist == null || this.whitelist.indexOf(value) > -1)) {
+    if (match != null && (this.whitelist == null || this.whitelist.indexOf(value.replace(/["']/g, '')) > -1)) {
       return true;
     }
     return false;

--- a/test/registry/attributor.js
+++ b/test/registry/attributor.js
@@ -8,6 +8,11 @@ let Size = new StyleAttributor('size', 'font-size', {
   scope: Registry.Scope.INLINE_ATTRIBUTE,
 });
 
+let Family = new StyleAttributor('family', 'font-family', {
+  scope: Registry.Scope.INLINE_ATTRIBUTE,
+  whitelist: ['Arial', 'Times New Roman']
+})
+
 let Id = new Attributor('id', 'id');
 
 let Align = new StyleAttributor('align', 'text-align', {
@@ -19,4 +24,4 @@ let Indent = new ClassAttributor('indent', 'indent', {
   scope: Registry.Scope.BLOCK_ATTRIBUTE,
 });
 
-Registry.register(Color, Size, Id, Align, Indent);
+Registry.register(Color, Size, Family, Id, Align, Indent);

--- a/test/unit/attributor.js
+++ b/test/unit/attributor.js
@@ -190,4 +190,13 @@ describe('Attributor', function() {
     let indentAttributor = Registry.query('indent');
     expect(indentAttributor.value(block.domNode)).toBeFalsy();
   });
+
+  it('removes quotes from attribute value when checking if canAdd', function () {
+    let node = document.createElement('strong');
+    let familyAttributor = Registry.query('family');
+    expect(familyAttributor.canAdd(node, 'Arial')).toBeTruthy();
+    expect(familyAttributor.canAdd(node, '"Times New Roman"')).toBeTruthy();
+    expect(familyAttributor.canAdd(node, 'monotype')).toBeFalsy();
+    expect(familyAttributor.canAdd(node, '"Lucida Grande"')).toBeFalsy();
+  });
 });


### PR DESCRIPTION
When font-family has multiple tokens (e.g "Times New Roman", ...), parchment's `Attributor` rejected a quoted value (as returned by Chrome, at least)