### PR TITLE
Add Option to Set Individual Parchment Registry Per Editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "http://quilljs.com/docs/parchment",
   "main": "dist/parchment.js",
-  "files": ["tsconfig.json", "dist", "src"],
+  "files": [
+    "tsconfig.json",
+    "dist",
+    "src"
+  ],
   "types": "dist/src/parchment.d.ts",
   "devDependencies": {
     "istanbul": "~0.4.5",

--- a/src/parchment.ts
+++ b/src/parchment.ts
@@ -20,6 +20,7 @@ let Parchment = {
   Scope: Registry.Scope,
 
   create: Registry.create,
+  destroyActiveRegistry: Registry.destroyActiveRegistry,
   find: Registry.find,
   query: Registry.query,
   register: Registry.register,

--- a/src/parchment.ts
+++ b/src/parchment.ts
@@ -23,6 +23,7 @@ let Parchment = {
   find: Registry.find,
   query: Registry.query,
   register: Registry.register,
+  setActiveRegistry: Registry.setActiveRegistry,
 
   Container: ContainerBlot,
   Format: FormatBlot,

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -34,6 +34,7 @@ let types: { [key: string]: Attributor | BlotConstructor } = {};
 let activeRegistryKey: string = null;
 let secondaryRegistries: { [key: string]: ActiveRegistry } = {};
 
+
 const EMPTY_REGISTRY: ActiveRegistry = {
   attributes: {},
   classes: {},
@@ -44,7 +45,7 @@ const EMPTY_REGISTRY: ActiveRegistry = {
 export const DATA_KEY = '__blot';
 
 // If the activeRegistryKey is not null, use secondaryRegistries per the respective editor
-function updateActiveRegistry(groupName: string, key: string, value: any) {
+export function updateActiveRegistry(groupName: string, key: string, value: any) {
   if (activeRegistryKey) {
     if (!secondaryRegistries[activeRegistryKey]) {
       secondaryRegistries[activeRegistryKey] = {
@@ -73,7 +74,7 @@ function updateActiveRegistry(groupName: string, key: string, value: any) {
   }
 }
 
-function getMatch(groupName: string, key: string) {
+export function getMatch(groupName: string, key: string) {
   if (activeRegistryKey) {
     if (!secondaryRegistries[activeRegistryKey]) {
       secondaryRegistries[activeRegistryKey] = {
@@ -200,11 +201,16 @@ export function register(...Definitions) {
   return Definition;
 }
 
+// For testing purposes only
+export function getActiveRegistry() {
+  return activeRegistryKey;
+}
+
 export function setActiveRegistry(registryKey: string | null) {
-    if (!registryKey.length) {
-      throw new ParchmentError('registryKey must be a valid string');
-    }
-    activeRegistryKey = registryKey;
+  if (!registryKey.length) {
+    throw new ParchmentError('registryKey must be a valid string');
+  }
+  activeRegistryKey = registryKey;
 }
 
 // For garbarge collecting

--- a/test/unit/registry.js
+++ b/test/unit/registry.js
@@ -1,6 +1,10 @@
 'use strict';
 
 describe('Registry', function() {
+  beforeEach(function() {
+    Registry.destroyActiveRegistry('abc');
+  });
+  
   describe('create()', function() {
     it('name', function() {
       let blot = Registry.create('bold');
@@ -130,6 +134,55 @@ describe('Registry', function() {
     it('type match and level mismatch', function() {
       let match = Registry.query('italic', Registry.Scope.BLOCK & Registry.Scope.BLOT);
       expect(match).toBeFalsy();
+    });
+  });
+
+  describe('setActiveRegistry()', function() {
+    it('set activeRegistryKey to string value', function() {
+      expect(Registry.getActiveRegistry()).toBe(null);
+      Registry.setActiveRegistry('abc');
+      const expected = 'abc';
+      const actual = Registry.getActiveRegistry();
+      expect(actual).toEqual(expected);
+    });
+
+    it('invalid', function() {
+      expect(function() {
+        Registry.setActiveRegistry(123);
+      }).toThrowError(/\[Parchment\]/);
+    })
+  });
+
+  describe('updateActiveRegistry() and getMatch()', function() {
+    beforeEach(function() {
+      Registry.destroyActiveRegistry('abc');
+    });
+    it('update global registry values', function() {
+      expect(Registry.getActiveRegistry()).toBe(null);
+      ['attributes', 'classes', 'tags', 'types'].forEach((groupName) => {
+        Registry.updateActiveRegistry(groupName, 'mockKey', 'mockValue');
+        expect(Registry.getMatch(groupName, 'mockKey')).toEqual('mockValue');
+      });
+    });
+
+    it('update editory specific registry values', function() {
+      expect(Registry.getActiveRegistry()).toBe(null);
+      Registry.setActiveRegistry('abc');
+      expect(Registry.getActiveRegistry()).toBe('abc');
+      ['attributes', 'classes', 'tags', 'types'].forEach((groupName) => {
+        Registry.updateActiveRegistry(groupName, 'mockKey', 'mockValue');
+        expect(Registry.getMatch(groupName, 'mockKey')).toEqual('mockValue');
+      });
+    });
+  });
+
+  describe('destroyActiveRegistry()', function() {
+    it('clear registry', function() {
+      expect(Registry.getActiveRegistry()).toBe(null);
+      Registry.setActiveRegistry('abc');
+      expect(Registry.getActiveRegistry()).toBe('abc');
+      Registry.destroyActiveRegistry('abc');
+      expect(Registry.getActiveRegistry()).toBe(null);
     });
   });
 });


### PR DESCRIPTION
This feature helps mitigate the allocated registry among different editors.  The current Parchment registry stores any newly registered formats at the module level.  This causes any registered format to be applied to every editor across the app or at lease on the current application route/view.  This can be an issue when attempting to extend the functionality of one editor without affecting the functionality of another.  For example, a full feature editor on one section of the page with a minimal editor on another section of the page.

This issue relates to #1101.  https://github.com/quilljs/quill/issues/1101

We add versatility to the Parchment registry by implementing an activeRegistryKey.  Using React for example, we can set the activeRegistryKey in the constructor and on componentWillUpdate.  Each time a specific editor changes, it first sets the activeRegistryKey to let Parchment know what registry to utilize.

The feature is useful in extending the versatility of Quill, and the approach allows for a clean, non-breaking change.  We don't need to worry about maintaining a specific instance of Parchment and the utility can be implemented without compromising the intricate flow of events.

We are using Quill for an assistive education app called [Blackboard] Learn Ultra (http://www.blackboard.com/).  We have built a custom editor component with React that uses a plugin based toolbar.  The rich text editor is used throughout different apps for student/teacher content authoring including blogging, forums, homework assignments, testing, and announcements.

If the feature is implemented, we can resolve some bugs and workarounds as well as add new features and improve the user experience of the editor component.