### PR TITLE
Fixes bug: Type 'undefined' is not assignable to type 'T'.

### DIFF
--- a/src/collection/linked-list.ts
+++ b/src/collection/linked-list.ts
@@ -1,17 +1,17 @@
 import LinkedNode from './linked-node';
 
 class LinkedList<T extends LinkedNode> {
-  head: T;
-  tail: T;
+  head: T | null;
+  tail: T | null;
   length: number;
 
   constructor() {
-    this.head = this.tail = undefined;
+    this.head = this.tail = null;
     this.length = 0;
   }
 
   append(...nodes: T[]): void {
-    this.insertBefore(nodes[0], undefined);
+    this.insertBefore(nodes[0], null);
     if (nodes.length > 1) {
       this.append.apply(this, nodes.slice(1));
     }
@@ -26,7 +26,8 @@ class LinkedList<T extends LinkedNode> {
     return false;
   }
 
-  insertBefore(node: T, refNode: T): void {
+  insertBefore(node: T | null, refNode: T | null): void {
+    if (!node) return
     node.next = refNode;
     if (refNode != null) {
       node.prev = refNode.prev;
@@ -42,7 +43,7 @@ class LinkedList<T extends LinkedNode> {
       node.prev = this.tail;
       this.tail = node;
     } else {
-      node.prev = undefined;
+      node.prev = null;
       this.head = this.tail = node;
     }
     this.length += 1;
@@ -68,16 +69,16 @@ class LinkedList<T extends LinkedNode> {
     this.length -= 1;
   }
 
-  iterator(curNode: T = this.head): () => T {
+  iterator(curNode: T | null = this.head): () => T | null {
     // TODO use yield when we can
-    return function(): T {
+    return function(): T | null {
       let ret = curNode;
       if (curNode != null) curNode = <T>curNode.next;
       return ret;
     };
   }
 
-  find(index: number, inclusive: boolean = false): [T, number] {
+  find(index: number, inclusive: boolean = false): [T | null, number] {
     let cur,
       next = this.iterator();
     while ((cur = next())) {
@@ -122,8 +123,8 @@ class LinkedList<T extends LinkedNode> {
     }
   }
 
-  map(callback: (cur: T) => any): any[] {
-    return this.reduce(function(memo, cur: T) {
+  map(callback: (cur: T | null) => any): any[] {
+    return this.reduce(function(memo: (T | null)[], cur: T | null) {
       memo.push(callback(cur));
       return memo;
     }, []);

--- a/src/collection/linked-node.ts
+++ b/src/collection/linked-node.ts
@@ -1,6 +1,6 @@
 interface LinkedNode {
-  prev: LinkedNode;
-  next: LinkedNode;
+  prev: LinkedNode | null;
+  next: LinkedNode | null;
 
   length(): number;
 }

--- a/test/unit/linked-list.js
+++ b/test/unit/linked-list.js
@@ -23,8 +23,8 @@ describe('LinkedList', function() {
       expect(this.list.length).toBe(1);
       expect(this.list.head).toBe(this.a);
       expect(this.list.tail).toBe(this.a);
-      expect(this.a.prev).toBeUndefined();
-      expect(this.a.next).toBeUndefined();
+      expect(this.a.prev).toBeNull();
+      expect(this.a.next).toBeNull();
     });
 
     it('insert to become head', function() {
@@ -33,22 +33,22 @@ describe('LinkedList', function() {
       expect(this.list.length).toBe(2);
       expect(this.list.head).toBe(this.a);
       expect(this.list.tail).toBe(this.b);
-      expect(this.a.prev).toBeUndefined();
+      expect(this.a.prev).toBeNull();
       expect(this.a.next).toBe(this.b);
       expect(this.b.prev).toBe(this.a);
-      expect(this.b.next).toBeUndefined();
+      expect(this.b.next).toBeNull();
     });
 
     it('insert to become tail', function() {
       this.list.append(this.a);
-      this.list.insertBefore(this.b, undefined);
+      this.list.insertBefore(this.b, null);
       expect(this.list.length).toBe(2);
       expect(this.list.head).toBe(this.a);
       expect(this.list.tail).toBe(this.b);
-      expect(this.a.prev).toBeUndefined();
+      expect(this.a.prev).toBeNull();
       expect(this.a.next).toBe(this.b);
       expect(this.b.prev).toBe(this.a);
-      expect(this.b.next).toBeUndefined();
+      expect(this.b.next).toBeNull();
     });
 
     it('insert in middle', function() {
@@ -67,8 +67,8 @@ describe('LinkedList', function() {
       expect(this.list.length).toBe(1);
       expect(this.list.head).toBe(this.b);
       expect(this.list.tail).toBe(this.b);
-      expect(this.list.head.prev).toBeUndefined();
-      expect(this.list.tail.next).toBeUndefined();
+      expect(this.list.head.prev).toBeNull();
+      expect(this.list.tail.next).toBeNull();
     });
 
     it('remove tail', function() {
@@ -77,8 +77,8 @@ describe('LinkedList', function() {
       expect(this.list.length).toBe(1);
       expect(this.list.head).toBe(this.a);
       expect(this.list.tail).toBe(this.a);
-      expect(this.list.head.prev).toBeUndefined();
-      expect(this.list.tail.next).toBeUndefined();
+      expect(this.list.head.prev).toBeNull();
+      expect(this.list.tail.next).toBeNull();
     });
 
     it('remove inner', function() {
@@ -87,8 +87,8 @@ describe('LinkedList', function() {
       expect(this.list.length).toBe(2);
       expect(this.list.head).toBe(this.a);
       expect(this.list.tail).toBe(this.c);
-      expect(this.list.head.prev).toBeUndefined();
-      expect(this.list.tail.next).toBeUndefined();
+      expect(this.list.head.prev).toBeNull();
+      expect(this.list.tail.next).toBeNull();
       expect(this.a.next).toBe(this.c);
       expect(this.c.prev).toBe(this.a);
       // Maintain references
@@ -100,8 +100,8 @@ describe('LinkedList', function() {
       this.list.append(this.a);
       this.list.remove(this.a);
       expect(this.list.length).toBe(0);
-      expect(this.list.head).toBeUndefined();
-      expect(this.list.tail).toBeUndefined();
+      expect(this.list.head).toBeNull();
+      expect(this.list.tail).toBeNull();
     });
 
     it('contains', function() {
@@ -117,8 +117,8 @@ describe('LinkedList', function() {
       this.list.remove(this.a);
       this.list.remove(this.c);
       this.list.append(this.b);
-      expect(this.b.prev).toBeUndefined();
-      expect(this.b.next).toBeUndefined();
+      expect(this.b.prev).toBeNull();
+      expect(this.b.next).toBeNull();
     });
   });
 
@@ -145,7 +145,7 @@ describe('LinkedList', function() {
       let d = next();
       expect(b).toBe(this.b);
       expect(c).toBe(this.c);
-      expect(d).toBeUndefined();
+      expect(d).toBeNull();
     });
 
     it('find', function() {


### PR DESCRIPTION
Added strict typing to linked-list.ts and files its affecting, in order to let projects with `strict: true` in `tsconfig.json` set, to use `quill`.

I'm planning to get feedback about changing `undefined` to `null`. I want to make sure that this doesn't affect anything in a negative way when making this change. Please let me know if there needs to a differentiation between `null` and `undefined`, in this case