### PR TITLE
Full mitigation for #42

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "http://quilljs.com/docs/parchment",
   "main": "dist/parchment.js",
-  "files": ["tsconfig.json", "dist", "src"],
+  "files": ["tsconfig.json", "dist"],
   "types": "dist/src/parchment.d.ts",
   "devDependencies": {
     "istanbul": "~0.4.5",


### PR DESCRIPTION
While Parchment compiling with strict null checks is great, if I'm not mistaken, the root cause of #42 is really that the compiler is giving priority to the `.ts` files under `src` over the compiled `.d.ts`/`.js`output under `dist`. TypeScript projects should be able to depend on this module without worrying about compatibility between its and their compilation settings.