### PR TITLE
Add support for attributors to be applied to both inline and block blots

### DIFF
--- a/src/blot/block.ts
+++ b/src/blot/block.ts
@@ -62,9 +62,8 @@ class BlockBlot extends ParentBlot implements Formattable {
   formatAt(index: number, length: number, name: string, value: any): void {
     if (Registry.query(name, Registry.Scope.BLOCK) != null) {
       this.format(name, value);
-    } else {
-      super.formatAt(index, length, name, value);
     }
+    super.formatAt(index, length, name, value);
   }
 
   insertAt(index: number, value: string, def?: any): void {

--- a/test/registry/attributor.js
+++ b/test/registry/attributor.js
@@ -24,4 +24,6 @@ let Indent = new ClassAttributor('indent', 'indent', {
   scope: Registry.Scope.BLOCK_ATTRIBUTE,
 });
 
-Registry.register(Color, Size, Family, Id, Align, Indent);
+let Comment = new Attributor('comment', 'data-comment');
+
+Registry.register(Color, Size, Family, Id, Align, Indent, Comment);

--- a/test/unit/attributor.js
+++ b/test/unit/attributor.js
@@ -204,4 +204,16 @@ describe('Attributor', function() {
     expect(familyAttributor.canAdd(node, 'monotype')).toBeFalsy();
     expect(familyAttributor.canAdd(node, '"Lucida Grande"')).toBeFalsy();
   });
+
+  it('add to both block and inline', function() {
+    let container = Registry.create('scroll');
+    let block = Registry.create('block');
+    let textBlot = Registry.create('text', 'Test');
+    block.appendChild(textBlot);
+    container.appendChild(block);
+    container.formatAt(0, 4, 'comment', 'test-value');
+    expect(textBlot.parent instanceof InlineBlot).toBe(true);
+    expect(textBlot.parent.domNode.dataset.comment).toEqual('test-value');
+    expect(block.domNode.dataset.comment).toEqual('test-value');
+  });
 });


### PR DESCRIPTION
I have a need for an Attributor in my application that adds an attribute to both inline and block blots. To support this, I've amended `BlockBlot.formatAt` to not assume that the relevant format is `BLOCK` xor `INLINE`, but could potentially be both.

I've added a test demonstrating the intended behavior for an Attributor configured this way.

I'd argue that this functionality is essential for ensuring that the DOM built by parchment comprehensively captures the formatting in a delta, like so:

```
// Delta
{ ops: [
  { insert: 'abc', attributes: { comment: 'inline' } },
  { insert: '\n',  attributes: { comment: 'block' } },
] }

// DOM
<div>
  <p data-comment="block">
    <span data-comment="inline">abc</span>
  </p>
</div>
```
