### PR TITLE
Add null checks to ScrollBlot domNode key

### DIFF
--- a/src/blot/scroll.ts
+++ b/src/blot/scroll.ts
@@ -71,7 +71,7 @@ class ScrollBlot extends ContainerBlot {
       if (blot == null || blot === this) return;
       if (blot.domNode.parentNode == null) return;
       // @ts-ignore
-      if (blot.domNode[Registry.DATA_KEY].mutations == null) {
+      if (blot.domNode[Registry.DATA_KEY] && blot.domNode[Registry.DATA_KEY].mutations == null) {
         // @ts-ignore
         blot.domNode[Registry.DATA_KEY].mutations = [];
       }
@@ -132,6 +132,8 @@ class ScrollBlot extends ContainerBlot {
       .map(function(mutation: MutationRecord) {
         let blot = Registry.find(mutation.target, true);
         if (blot == null) return null;
+        // @ts-ignore
+        if (blot.domNode[Registry.DATA_KEY] == null) return null;
         // @ts-ignore
         if (blot.domNode[Registry.DATA_KEY].mutations == null) {
           // @ts-ignore


### PR DESCRIPTION
I noticed a few instances where `blot.domNode[Registry.DATA_KEY]` is null, resulting in a `Uncaught TypeError: Cannot read property 'mutations' of undefined` error during ScrollBlot.update or ScrollBlot.optimize calls. This PR adds two additional checks to prevent these methods from failing loudly to the browser console. 

If need be, I can try to hack together a reproduction of the error. Is it indicative of something going wrong before this point to cause `blot.domNode[Registry.DATA_KEY]` to be null in the first place?