### PR TITLE
`TextBlot.split` shouldn't split text if `index` is invalid

### DIFF
--- a/src/blot/text.ts
+++ b/src/blot/text.ts
@@ -67,7 +67,7 @@ class TextBlot extends LeafBlot implements Leaf {
   split(index: number, force: boolean = false): Blot {
     if (!force) {
       if (index === 0) return this;
-      if (index === this.length()) return this.next;
+      if (index >= this.length()) return this.next;
     }
     let after = Registry.create(this.domNode.splitText(index));
     this.parent.insertBefore(after, this.next);

--- a/test/unit/text.js
+++ b/test/unit/text.js
@@ -57,8 +57,10 @@ describe('TextBlot', function() {
     container.appendChild(textBlot);
     let before = textBlot.split(0);
     let after = textBlot.split(4);
+    let invalid = textBlot.split(5);
     expect(before).toEqual(textBlot);
     expect(after).toBe(null);
+    expect(invalid).toBe(null);
   });
 
   it('split() force', function() {


### PR DESCRIPTION
This can happen if the `length` value created in Quill's `Editor.applyDelta` method was created from a string containing a unicode character with multiple code points. For example, this operation contains `ú` or `\u0075\u0301`:

```
{
  "insert": "LaCroix's Cúrate collection of sparkling waters",
  "attributes": {
    "link": "http://www.lacroixwater.com/"
   }
}
```

The problem arises because the computed length of that string in `applyDelta` is 48, but later in the Quill lifecycle* the string length is 47 because the `ú` has been converted to a `ú` or `\u00FA`. Thus, `TextBlot.split` is called with an `index` that is greater than the length of the string, resulting in the following error:

```
DOMException: Failed to execute 'splitText' on 'Text': The offset 48 is larger than the Text node's length.
    at TextWithSoftWrapsBlot.e.split
```

This should probably be solved by dealing with unicode characters differently elsewhere, but this small change doesn't seem to me to have any downsides while fixing the error.

\* Tested in Chrome 70.0.3538.110 on MacOS 10.14.1