### PR TITLE
ignore enumerable properties from prototype when iterating over node …

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -84,7 +84,7 @@ export function query(
     const className = (query.getAttribute('class') || '')
       .split(/\s+/)
       .filter(className => className in classes)
-      .pop();
+      .shift();
 
     match = className ? classes[className] : tags[query.tagName];
   }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -81,12 +81,12 @@ export function query(
       match = types['inline'];
     }
   } else if (query instanceof HTMLElement) {
-    let names = (query.getAttribute('class') || '').split(/\s+/);
-    for (let i in names) {
-      match = classes[names[i]];
-      if (match) break;
-    }
-    match = match || tags[query.tagName];
+    const className = (query.getAttribute('class') || '')
+      .split(/\s+/)
+      .filter(className => className in classes)
+      .pop();
+
+    match = className ? classes[className] : tags[query.tagName];
   }
   if (match == null) return null;
   // @ts-ignore


### PR DESCRIPTION
for(var i in names) iterates over enumerable properties from prototype (added by Array.prototype.propName = propValue) and in this case query would return a property instead of a BlotConstructor ( as both names and classes would have the enumerable properties ).

In my case query returned the toString function added on Array by some legacy code.