### PR TITLE
Prevent to return double double quoted values

### DIFF
--- a/src/attributor/style.ts
+++ b/src/attributor/style.ts
@@ -11,6 +11,10 @@ function camelize(name: string): string {
   return parts[0] + rest;
 }
 
+function removeDoubleDoubleQuotes(value: string): string {
+  return value.replace(/""/g, '"');
+}
+
 class StyleAttributor extends Attributor {
   static keys(node: Element): string[] {
     return (node.getAttribute('style') || '').split(';').map(function(value) {
@@ -36,7 +40,7 @@ class StyleAttributor extends Attributor {
 
   value(node: HTMLElement): string {
     // @ts-ignore
-    let value = node.style[camelize(this.keyName)];
+    let value = removeDoubleDoubleQuotes(node.style[camelize(this.keyName)]);
     return this.canAdd(node, value) ? value : '';
   }
 }


### PR DESCRIPTION
Hi, 

By working with Quill, I found a bug when you declare custom style attributor for font-family.
I described the issue here : https://github.com/quilljs/quill/issues/2863 
The format retrieved a value like : `customFontFamily: ""Arial""` which is broken.
To prevent that behavior we can make sur to replace all double double quotes to be returned as value.