### PR TITLE
More resilient to DOM polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parchment",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A document model for rich text editors",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "http://quilljs.com/docs/parchment",

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -80,7 +80,7 @@ export function query(
     } else if (query & Scope.LEVEL & Scope.INLINE) {
       match = types['inline'];
     }
-  } else if (query instanceof HTMLElement) {
+  } else if (query instanceof HTMLElement || query instanceof Element) {
     let names = (query.getAttribute('class') || '').split(/\s+/);
     for (let i in names) {
       match = classes[names[i]];


### PR DESCRIPTION
I'm an engineer at Klaviyo and we've come across an issue which seems to be occurring quite often.

In part of our product, we inject javascript on our clients' websites to display dynamic content and forms. A lot of sites seem to have google's [AmpHtml](https://github.com/ampproject/amphtml/) installed, presumably for mobile viewing.

AmpHtml adds polyfills which override the native code for `HTMLElement` and a lot of other objects. This breaks the `element instanceof HTMLElement` check which parchment uses. [Here's the issue filed on their project](https://github.com/ampproject/amphtml/issues/26424)

This PR makes the `query()` function more resilient to polyfills by other 3rd part libraries.

In the past a day, we seen close to 30K errors due to this polyfill

![image](https://user-images.githubusercontent.com/1566265/72908285-4597e480-3d03-11ea-9f20-1e38479fe3dd.png)

Granted that this isn't exactly a parchment issue, We'd be immensely grateful if this PR was accepted since expecting amphtml maintainers to address this issue seems quite unlikely in the short term.
