### PR TITLE
Fix compatibility with TypeScript 3.7

### DIFF
--- a/src/blot/abstract/parent.ts
+++ b/src/blot/abstract/parent.ts
@@ -314,8 +314,8 @@ class ParentBlot extends ShadowBlot implements Parent {
     const removedNodes: Node[] = [];
     mutations.forEach(mutation => {
       if (mutation.target === this.domNode && mutation.type === 'childList') {
-        addedNodes.push.apply(addedNodes, mutation.addedNodes);
-        removedNodes.push.apply(removedNodes, mutation.removedNodes);
+        addedNodes.push(...mutation.addedNodes);
+        removedNodes.push(...mutation.removedNodes);
       }
     });
     removedNodes.forEach((node: Node) => {


### PR DESCRIPTION
TypeScript 3.7 introduces some changes to DOM related types, that `addedNodes` is now a `NodeList` instead of `Node[]`, so users who using TypeScript 3.7 in their project won't be able to compile parchment.

This pr changes `.apply` to spread syntax to address this issue. Performance-wise
they are similar and compatibility-wise we've already used spread syntax in the
codebase so that should be fine.

**Test Plan**
Upgrade TypeScript to 3.7 and run `npm run build`. It should build without any errors. 

Closes #72, #78.