### PR TITLE
fix: blots can be created in iframes

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -52,7 +52,7 @@ export function create(input: Node | string | Scope, value?: any): Blot {
   let BlotClass = <BlotConstructor>match;
   let node =
     // @ts-ignore
-    input instanceof Node || input['nodeType'] === Node.TEXT_NODE ? input : BlotClass.create(value);
+    isNode(input) || input['nodeType'] === Node.TEXT_NODE ? input : BlotClass.create(value);
   return new BlotClass(<Node>node, value);
 }
 
@@ -80,7 +80,7 @@ export function query(
     } else if (query & Scope.LEVEL & Scope.INLINE) {
       match = types['inline'];
     }
-  } else if (query instanceof HTMLElement) {
+  } else if (isHTMLElement(query)) {
     let names = (query.getAttribute('class') || '').split(/\s+/);
     for (let i in names) {
       match = classes[names[i]];
@@ -130,4 +130,32 @@ export function register(...Definitions: any[]): any {
     }
   }
   return Definition;
+}
+
+function isHTMLElement(value: any): value is HTMLElement {
+  if (value instanceof HTMLElement) {
+    return true;
+  }
+
+  if (value.ownerDocument) {
+    const elementWindow = value.ownerDocument.defaultView || value.ownerDocument.parentWindow;
+
+    return value instanceof elementWindow.HTMLElement;
+  }
+  
+  return false;
+}
+
+function isNode(value: any): value is Node {
+  if (value instanceof Node) {
+    return true;
+  }
+
+  if (value.ownerDocument) {
+    const elementWindow = value.ownerDocument.defaultView || value.ownerDocument.parentWindow;
+
+    return value instanceof elementWindow.Node;
+  }
+  
+  return false;
 }

--- a/test/unit/registry.js
+++ b/test/unit/registry.js
@@ -15,6 +15,19 @@ describe('Registry', function() {
       expect(blot.statics.blotName).toBe('bold');
     });
 
+    it('node in iframe', function() {
+      const testIFrame = setupTestContainer();
+      let node = document.createElement('strong');
+      testIFrame.contentDocument.body.appendChild(node);
+      let blot = Registry.create(node);
+
+      expect(blot instanceof BoldBlot).toBe(true);
+      expect(blot.statics.blotName).toBe('bold');
+      expect(blot.domNode).toBe(node);
+
+      document.body.removeChild(testIFrame);
+    });
+
     it('block', function() {
       let blot = Registry.create(Registry.Scope.BLOCK_BLOT);
       expect(blot instanceof BlockBlot).toBe(true);
@@ -97,6 +110,15 @@ describe('Registry', function() {
       expect(Registry.query(node)).toBe(AuthorBlot);
     });
 
+    it('class in iFrame', function() {
+      const testIFrame = setupTestContainer();
+      let node = document.createElement('em');
+      node.setAttribute('class', 'author-blot');
+      testIFrame.contentDocument.body.appendChild(node);
+
+      expect(Registry.query(node)).toBe(AuthorBlot);
+    });
+
     it('type mismatch', function() {
       let match = Registry.query('italic', Registry.Scope.ATTRIBUTE);
       expect(match).toBeFalsy();
@@ -133,3 +155,17 @@ describe('Registry', function() {
     });
   });
 });
+
+function setupTestContainer() {
+  const testFrame = document.createElement('iframe');
+  testFrame.setAttribute('width', 800);
+  testFrame.setAttribute('height', 1000);
+  testFrame.setAttribute('frameborder', 0);
+  document.body.appendChild(testFrame);
+  testFrame.contentWindow.document.open();
+  testFrame.contentWindow.document.write(
+    `<!DOCTYPE html>\n<html><head></head><body></body></html>`,
+  );
+  testFrame.contentWindow.document.close();
+  return testFrame;
+}


### PR DESCRIPTION
This is in context of an issue in quill https://github.com/quilljs/quill/issues/2633

In some browsers HTMLElement (or other browser DOM types) are redefined in iFrames. This means parchment's registry create functions break when given nodes that are in iFrames. With this change it should be fixed.

This is required in order for https://github.com/quilljs/quill/pull/2953 to also work.