### PR TITLE
fix: blots can be created in iframes

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -41,7 +41,7 @@ export default class Registry implements RegistryInterface {
     const blotClass = match as BlotConstructor;
     const node =
       // @ts-ignore
-      input instanceof Node || input.nodeType === Node.TEXT_NODE
+      this.isNode(input) || input.nodeType === Node.TEXT_NODE
         ? input
         : blotClass.create(value);
 
@@ -70,7 +70,7 @@ export default class Registry implements RegistryInterface {
       } else if (query & Scope.LEVEL & Scope.INLINE) {
         match = this.types.inline;
       }
-    } else if (query instanceof HTMLElement) {
+    } else if (this.isHTMLElement(query)) {
       const names = (query.getAttribute('class') || '').split(/\s+/);
       names.some(name => {
         match = this.classes[name];
@@ -132,5 +132,25 @@ export default class Registry implements RegistryInterface {
       }
     }
     return definition;
+  }
+
+  private isHTMLElement(value: any): value is HTMLElement {
+    if (value.ownerDocument === undefined) {
+      return false;
+    }
+
+    const elementWindow = value.ownerDocument.defaultView || value.ownerDocument.parentWindow;
+    return value instanceof HTMLElement
+      || value instanceof elementWindow.HTMLElement;
+  }
+  
+  private isNode(value: any): value is Node {
+    if (value.ownerDocument === undefined) {
+      return false;
+    }
+
+    const elementWindow = value.ownerDocument.defaultView || value.ownerDocument.parentWindow;
+    return value instanceof Node
+      || value instanceof elementWindow.Node;
   }
 }

--- a/test/unit/registry.js
+++ b/test/unit/registry.js
@@ -15,6 +15,19 @@ describe('TestRegistry', function() {
       expect(blot.statics.blotName).toBe('bold');
     });
 
+    it('node in iframe', function() {
+      const testIFrame = setupTestContainer();
+      let node = document.createElement('strong');
+      testIFrame.contentDocument.body.appendChild(node);
+      let blot = TestRegistry.create(this.scroll, node);
+
+      expect(blot instanceof BoldBlot).toBe(true);
+      expect(blot.statics.blotName).toBe('bold');
+      expect(blot.domNode).toBe(node);
+
+      document.body.removeChild(testIFrame);
+    });
+
     it('block', function() {
       let blot = TestRegistry.create(this.scroll, Scope.BLOCK_BLOT);
       expect(blot instanceof BlockBlot).toBe(true);
@@ -101,6 +114,17 @@ describe('TestRegistry', function() {
       expect(TestRegistry.query(node)).toBe(AuthorBlot);
     });
 
+    it('class in iFrame', function() {
+      const testIFrame = setupTestContainer();
+      let node = document.createElement('em');
+      node.setAttribute('class', 'author-blot');
+      testIFrame.contentDocument.body.appendChild(node);
+
+      expect(TestRegistry.query(node)).toBe(AuthorBlot);
+
+      document.body.removeChild(testIFrame);
+    });
+
     it('type mismatch', function() {
       let match = TestRegistry.query('italic', Scope.ATTRIBUTE);
       expect(match).toBeFalsy();
@@ -137,3 +161,17 @@ describe('TestRegistry', function() {
     });
   });
 });
+
+function setupTestContainer() {
+  const testFrame = document.createElement('iframe');
+  testFrame.setAttribute('width', 800);
+  testFrame.setAttribute('height', 1000);
+  testFrame.setAttribute('frameborder', 0);
+  document.body.appendChild(testFrame);
+  testFrame.contentWindow.document.open();
+  testFrame.contentWindow.document.write(
+    `<!DOCTYPE html>\n<html><head></head><body></body></html>`,
+  );
+  testFrame.contentWindow.document.close();
+  return testFrame;
+}


### PR DESCRIPTION
Same as https://github.com/quilljs/parchment/pull/81 except for the 2.0 branch. I tested it locally with https://github.com/quilljs/quill/pull/2953 and it seems to work nicely