### PR TITLE
Remove unused import  specifier in registry.ts

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,5 +1,5 @@
 import Attributor from './attributor/attributor';
-import { Blot, Formattable } from './blot/abstract/blot';
+import { Blot } from './blot/abstract/blot';
 
 export interface BlotConstructor {
   blotName: string;


### PR DESCRIPTION
`Formattable` is imported in regisgry.ts but isn't used. 