### PR TITLE
Output types in 2.0 build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "es6",
     "target": "es6",
     "declaration": true,
+    "declarationDir": "dist/src",
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "es6",
     "target": "es6",
-    "declaration": false,
+    "declaration": true,
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true


### PR DESCRIPTION
@jhchen this allows the 2.x builds to output types the same way the 1.x packages do.