### PR TITLE
fix invalid condition in insertBefore

### DIFF
--- a/src/blot/abstract/parent.ts
+++ b/src/blot/abstract/parent.ts
@@ -221,7 +221,7 @@ class ParentBlot extends ShadowBlot implements Parent {
       refDomNode = refBlot.domNode;
     }
     if (
-      this.domNode.parentNode !== childBlot.domNode ||
+      this.domNode !== childBlot.domNode.parentNode ||
       this.domNode.nextSibling !== refDomNode
     ) {
       this.domNode.insertBefore(childBlot.domNode, refDomNode);


### PR DESCRIPTION
`this.domNode.parentNode !== childBlot.domNode` is true that cause redundant insert. 
Because in many cases,  `childBlot.domNode.parentNode` is `this.domNode`