### PR TITLE
Delete selection with color style makes editor corrupt

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -125,6 +125,12 @@ export default class Registry implements RegistryInterface {
           ? definition.tagName
           : [definition.tagName];
         tagNames.forEach((tag: string) => {
+          if (tag === 'FONT') {
+            throw new Error(
+              `${definition.blotName ||
+                definition.attrName}: "font" cannot be used as tagName.`,
+            );
+          }
           if (this.tags[tag] == null || definition.className == null) {
             this.tags[tag] = definition;
           }


### PR DESCRIPTION
**To reproduce:**
1. Type "123".
2. Make "2" colored.
3. Select "23".
4. Press "q" (just a random char).

**Expected:**

"1q" where q is colored.

**Actually:**

Editor is empty.



![CleanShot 2021-05-02 at 21 04 38](https://user-images.githubusercontent.com/635902/116814185-13be3080-ab8a-11eb-894c-23ee4d559877.gif)

Possibility fixes https://github.com/quilljs/quill/issues/2933

The cause is when pressing "q", Chrome wraps "q" with `<font color="xxx"/>" instead of its original parent element, which causes `makeAttachedBlot` creates a new empty inline blot to replace the <font/>. However, `makeAttachedBlot` doesn't `#build()` the newly created blot, thus the text node "q" inside it doesn't belong to a blot.

Another possible fix is to let `makeAttachedBlot` invoke `blot.build` after the blot has been built and node's children have been moved into blot. However, that will make the inline blot not have any styles and will be unwrapped, which will end up with `1q` where `q` is unstyled. What's more, because `q` is unwrapped, the `nativeRange` stored in selection on the before optimize event will not be in the document anymore, and the selection will be moved to the beginning of the editor.