### PR TITLE
🏷️ Emit type definitions

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,15 @@
   "compilerOptions": {
     "module": "es6",
     "target": "es6",
-    "declaration": false,
+    "declaration": true,
+    "outDir": "dist",
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true
   },
-  "exclude": ["node_modules", "test"]
+  "exclude": [
+    "node_modules",
+    "test",
+    "dist"
+  ]
 }


### PR DESCRIPTION
This change emits type definitions so that consumers can import the
compiled module from `/dist`, but still have type safety in
TypeScript.