### PR TITLE
Handle permission denied error for Firefox

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -23,7 +23,17 @@ export default class Registry implements RegistryInterface {
       return this.blots.get(node) || null;
     }
     if (bubble) {
-      return this.find(node.parentNode, bubble);
+      let parentNode: Node | null = null;
+      try {
+        parentNode = node.parentNode;
+      } catch (err) {
+        // Probably hit a permission denied error.
+        // A known case is in Firefox, event targets can be anonymous DIVs
+        // inside an input element.
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=208427
+        return null;
+      }
+      return this.find(parentNode, bubble);
     }
     return null;
   }

--- a/test/unit/registry.js
+++ b/test/unit/registry.js
@@ -92,6 +92,19 @@ describe('TestRegistry', function () {
       expect(TestRegistry.find(blockNode.firstChild)).toBeFalsy();
       expect(TestRegistry.find(blockNode.firstChild, true)).toBeFalsy();
     });
+
+    it('restricted parent', function () {
+      let blockBlot = TestRegistry.create(this.scroll, 'block');
+      let textNode = document.createTextNode('Test');
+      blockBlot.domNode.appendChild(textNode);
+      Object.defineProperty(textNode, 'parentNode', {
+        get() {
+          throw new Error('Permission denied to access property "parentNode"');
+        },
+      });
+      expect(TestRegistry.find(textNode)).toEqual(null);
+      expect(TestRegistry.find(textNode, true)).toEqual(null);
+    });
   });
 
   describe('query()', function () {


### PR DESCRIPTION
Firefox sometimes returns anonymous DIVs as targets for events whose real targets should be inputs: https://bugzilla.mozilla.org/show_bug.cgi?id=208427.

We should handle the case when users pass those anonymous DIVs to `Registry.find()`.