### PR TITLE
Scroll#find() should not return blots in child scrolls

### DIFF
--- a/src/blot/scroll.ts
+++ b/src/blot/scroll.ts
@@ -44,7 +44,14 @@ class ScrollBlot extends ParentBlot implements Root {
   }
 
   public find(node: Node | null, bubble = false): Blot | null {
-    return this.registry.find(node, bubble);
+    const blot = this.registry.find(node, bubble);
+    if (!blot) {
+      return null;
+    }
+    if (blot.scroll === this) {
+      return blot;
+    }
+    return bubble ? this.find(blot.scroll.domNode.parentNode, true) : null;
   }
 
   public query(
@@ -181,7 +188,7 @@ class ScrollBlot extends ParentBlot implements Root {
     const mutationsMap = new WeakMap();
     mutations
       .map((mutation: MutationRecord) => {
-        const blot = Registry.find(mutation.target, true);
+        const blot = this.find(mutation.target, true);
         if (blot == null) {
           return null;
         }

--- a/test/unit/attributor.js
+++ b/test/unit/attributor.js
@@ -162,7 +162,7 @@ describe('Attributor', function () {
   });
 
   it('add to block', function () {
-    let container = this.scroll.create('scroll');
+    let container = this.scroll.create('block');
     let block = this.scroll.create('header', 'h1');
     container.appendChild(block);
     block.format('align', 'right');


### PR DESCRIPTION
Previously, `Scroll#find()` can return blots inside child scrolls. This is actually not expected as child scrolls should be managed by embed blots that render them.