### PR TITLE
Ime-fixup

### DIFF
--- a/src/blot/abstract/parent.ts
+++ b/src/blot/abstract/parent.ts
@@ -216,16 +216,16 @@ class ParentBlot extends ShadowBlot implements Parent {
     }
     let refDomNode: Node | null = null;
     this.children.insertBefore(childBlot, refBlot || null);
-    childBlot.parent = this;
     if (refBlot != null) {
       refDomNode = refBlot.domNode;
     }
     if (
-      this.domNode.parentNode !== childBlot.domNode ||
-      this.domNode.nextSibling !== refDomNode
+      childBlot.domNode.parentNode !== this.domNode ||
+      childBlot.domNode.nextSibling !== refDomNode
     ) {
       this.domNode.insertBefore(childBlot.domNode, refDomNode);
     }
+    childBlot.parent = this;
     childBlot.attach();
   }
 


### PR DESCRIPTION
Fixes https://github.com/quilljs/quill/issues/1453

It's a backport of the commit 17f61235182bda64ba7535dab6ee5a68a4a807a9
for version 2.0

Update:

Outdated (detached) blot updates lead to inconsistency between parchment and real DOM. Reproduces only in Safari.
Example:
```
// dom structure
div <-- editor root
  p
    a
      strong
        #text

// perform insert operation at the end of the paragraph --> insert(#text, strong)
// resulting DOM structure
div <-- editor root
  p
    strong
      a
        #text
      #text

// after parchment optimisation phase
div <-- editor root
  p
    br
```
The problem is when updating parchment from mutation records some blots are created with the same DOM node in the registry, so in order to skip the outdated nodes we should take them right from the registry each time.
Video: https://www.loom.com/share/2a6fbc392f4e459da274a034bcaecdb6