### PR TITLE
🏷️ Update `tagName` to optionally be an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ At the very minimum a Blot must be named with a static `blotName` and associated
 class Blot {
   static blotName: string;
   static className: string;
-  static tagName: string;
+  static tagName: string | string[];
   static scope: Scope;
 
   domNode: Node;

--- a/src/blot/abstract/blot.ts
+++ b/src/blot/abstract/blot.ts
@@ -6,7 +6,7 @@ import Scope from '../../scope';
 export interface BlotConstructor {
   blotName: string;
   className?: string;
-  tagName: string;
+  tagName: string | string[];
   new (scroll: Root, node: Node, value?: any): Blot;
   create(value?: any): Node;
 }
@@ -25,7 +25,7 @@ export interface Blot extends LinkedNode {
     defaultChild?: BlotConstructor;
     requiredContainer?: BlotConstructor;
     scope: Scope;
-    tagName: string;
+    tagName: string | string[];
   };
 
   attach(): void;

--- a/src/blot/abstract/container.ts
+++ b/src/blot/abstract/container.ts
@@ -5,7 +5,7 @@ import ParentBlot from './parent';
 class ContainerBlot extends ParentBlot {
   public static blotName = 'container';
   public static scope = Scope.BLOCK_BLOT;
-  public static tagName: string;
+  public static tagName: string | string[];
 
   public prev!: BlockBlot | ContainerBlot | null;
   public next!: BlockBlot | ContainerBlot | null;

--- a/src/blot/abstract/shadow.ts
+++ b/src/blot/abstract/shadow.ts
@@ -8,7 +8,7 @@ class ShadowBlot implements Blot {
   public static className: string;
   public static requiredContainer: BlotConstructor;
   public static scope: Scope;
-  public static tagName: string;
+  public static tagName: string | string[];
 
   public static create(value: any): Node {
     if (this.tagName == null) {


### PR DESCRIPTION
The `Registry` [already allows][1] the `tagName` property to be an array.

This change updates the types to reflect that.

[1]: https://github.com/quilljs/parchment/blob/634e50f4d73a3351952250146510332dbc0af961/src/registry.ts#L127