### PR TITLE
Allow non-string values for attributors

### DIFF
--- a/src/attributor/attributor.ts
+++ b/src/attributor/attributor.ts
@@ -29,11 +29,11 @@ export default class Attributor {
     }
   }
 
-  public add(node: HTMLElement, value: any): boolean {
+  public add(node: HTMLElement, value: string | number): boolean {
     if (!this.canAdd(node, value)) {
       return false;
     }
-    node.setAttribute(this.keyName, value);
+    node.setAttribute(this.keyName, String(value));
     return true;
   }
 

--- a/src/attributor/attributor.ts
+++ b/src/attributor/attributor.ts
@@ -29,7 +29,7 @@ export default class Attributor {
     }
   }
 
-  public add(node: HTMLElement, value: string): boolean {
+  public add(node: HTMLElement, value: any): boolean {
     if (!this.canAdd(node, value)) {
       return false;
     }
@@ -52,7 +52,7 @@ export default class Attributor {
     node.removeAttribute(this.keyName);
   }
 
-  public value(node: HTMLElement): string {
+  public value(node: HTMLElement): any {
     const value = node.getAttribute(this.keyName);
     if (this.canAdd(node, value) && value) {
       return value;

--- a/src/attributor/class.ts
+++ b/src/attributor/class.ts
@@ -14,7 +14,7 @@ class ClassAttributor extends Attributor {
       .map((name) => name.split('-').slice(0, -1).join('-'));
   }
 
-  public add(node: HTMLElement, value: any): boolean {
+  public add(node: HTMLElement, value: string | number): boolean {
     if (!this.canAdd(node, value)) {
       return false;
     }

--- a/src/attributor/class.ts
+++ b/src/attributor/class.ts
@@ -14,7 +14,7 @@ class ClassAttributor extends Attributor {
       .map((name) => name.split('-').slice(0, -1).join('-'));
   }
 
-  public add(node: HTMLElement, value: string): boolean {
+  public add(node: HTMLElement, value: any): boolean {
     if (!this.canAdd(node, value)) {
       return false;
     }
@@ -33,7 +33,7 @@ class ClassAttributor extends Attributor {
     }
   }
 
-  public value(node: HTMLElement): string {
+  public value(node: HTMLElement): any {
     const result = match(node, this.keyName)[0] || '';
     const value = result.slice(this.keyName.length + 1); // +1 for hyphen
     return this.canAdd(node, value) ? value : '';

--- a/src/attributor/style.ts
+++ b/src/attributor/style.ts
@@ -17,7 +17,7 @@ class StyleAttributor extends Attributor {
     });
   }
 
-  public add(node: HTMLElement, value: string): boolean {
+  public add(node: HTMLElement, value: any): boolean {
     if (!this.canAdd(node, value)) {
       return false;
     }
@@ -34,7 +34,7 @@ class StyleAttributor extends Attributor {
     }
   }
 
-  public value(node: HTMLElement): string {
+  public value(node: HTMLElement): any {
     // @ts-expect-error Fix me later
     const value = node.style[camelize(this.keyName)];
     return this.canAdd(node, value) ? value : '';

--- a/src/attributor/style.ts
+++ b/src/attributor/style.ts
@@ -17,7 +17,7 @@ class StyleAttributor extends Attributor {
     });
   }
 
-  public add(node: HTMLElement, value: any): boolean {
+  public add(node: HTMLElement, value: string | number): boolean {
     if (!this.canAdd(node, value)) {
       return false;
     }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -10,7 +10,7 @@ import Scope from './scope';
 export type RegistryDefinition = Attributor | BlotConstructor;
 
 export interface RegistryInterface {
-  create(sroll: Root, input: Node | string | Scope, value?: any): Blot;
+  create(scroll: Root, input: Node | string | Scope, value?: any): Blot;
   query(query: string | Node | Scope, scope: Scope): RegistryDefinition | null;
   register(...definitions: any[]): any;
 }

--- a/tests/types/attributor.test-d.ts
+++ b/tests/types/attributor.test-d.ts
@@ -1,0 +1,12 @@
+import { assertType } from 'vitest';
+import { ClassAttributor } from '../../src/parchment';
+
+class IndentAttributor extends ClassAttributor {
+  value(node: HTMLElement) {
+    return parseInt(super.value(node), 10) || undefined;
+  }
+}
+
+assertType<any>(
+  new IndentAttributor('indent', 'indent').value(document.createElement('div')),
+);


### PR DESCRIPTION
This change reflects our current state. Some attributors (e.g. indent) allow non-string values.