### PR TITLE
Relax argument typing requirements for BlotConstructor

### DIFF
--- a/src/attributor/attributor.ts
+++ b/src/attributor/attributor.ts
@@ -29,11 +29,11 @@ export default class Attributor {
     }
   }
 
-  public add(node: HTMLElement, value: string | number): boolean {
+  public add(node: HTMLElement, value: any): boolean {
     if (!this.canAdd(node, value)) {
       return false;
     }
-    node.setAttribute(this.keyName, String(value));
+    node.setAttribute(this.keyName, value);
     return true;
   }
 

--- a/src/attributor/class.ts
+++ b/src/attributor/class.ts
@@ -14,7 +14,7 @@ class ClassAttributor extends Attributor {
       .map((name) => name.split('-').slice(0, -1).join('-'));
   }
 
-  public add(node: HTMLElement, value: string | number): boolean {
+  public add(node: HTMLElement, value: any): boolean {
     if (!this.canAdd(node, value)) {
       return false;
     }

--- a/src/attributor/style.ts
+++ b/src/attributor/style.ts
@@ -17,7 +17,7 @@ class StyleAttributor extends Attributor {
     });
   }
 
-  public add(node: HTMLElement, value: string | number): boolean {
+  public add(node: HTMLElement, value: any): boolean {
     if (!this.canAdd(node, value)) {
       return false;
     }

--- a/src/blot/abstract/blot.ts
+++ b/src/blot/abstract/blot.ts
@@ -7,7 +7,7 @@ export interface BlotConstructor {
   blotName: string;
   className?: string;
   tagName: string | string[];
-  new (scroll: Root, node: Node, value?: any): Blot;
+  new (...args: any[]): Blot;
   create(value?: any): Node;
 }
 


### PR DESCRIPTION
In Quill, Scroll may accept a registry as the first parameter. This change reflects that fact.